### PR TITLE
Fix phony tests

### DIFF
--- a/app/models/gringotts/settings.rb
+++ b/app/models/gringotts/settings.rb
@@ -5,6 +5,7 @@ module Gringotts
     
     belongs_to :vault
     validates  :vault_id,     presence: true, uniqueness: true
+    phony_normalize :phone_number, :default_country_code => 'US'
     validates  :phone_number, presence: true, uniqueness: true, phony_plausible: true
     
     after_update :unconfirm!, :if => :phone_number_changed?

--- a/app/views/gringotts/verification/confirm.html.erb
+++ b/app/views/gringotts/verification/confirm.html.erb
@@ -21,7 +21,7 @@
       </div><!-- /step -->
 
       <div class="phone-number">
-        <%= @gringotts.phone_number %>
+        <%= @gringotts.phone_number.phony_formatted(:format => :international, :spaces => '-') %>
       </div>
       
       <%= render :partial => "code_form" %>

--- a/features/step_definitions/devise_steps.rb
+++ b/features/step_definitions/devise_steps.rb
@@ -41,7 +41,7 @@ def sign_in
   visit '/users/sign_in'
   fill_in "user_email", :with => @visitor[:email]
   fill_in "user_password", :with => @visitor[:password]
-  click_button "Log in"
+  find('input[type="submit"]').click
 end
 
 def sign_out

--- a/features/step_definitions/devise_steps.rb
+++ b/features/step_definitions/devise_steps.rb
@@ -41,7 +41,7 @@ def sign_in
   visit '/users/sign_in'
   fill_in "user_email", :with => @visitor[:email]
   fill_in "user_password", :with => @visitor[:password]
-  click_button "Sign in"
+  click_button "Log in"
 end
 
 def sign_out

--- a/spec/factories/gringotts_settings.rb
+++ b/spec/factories/gringotts_settings.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     end
       
     factory :good_us_phone_number_settings do
-      phone_number "(444) 444-4444"
+      phone_number '+1 (444) 444-4444'
     
       factory :confirmed_settings do
         vault_id { FactoryGirl.create(:confirmed_gringotts_vault).id }
@@ -22,7 +22,7 @@ FactoryGirl.define do
     end
       
     factory :good_pe_phone_number_settings do
-      phone_number "(084) 791224"
+      phone_number "+41 44 111 22 33"
     end
     
   end

--- a/spec/factories/gringotts_settings.rb
+++ b/spec/factories/gringotts_settings.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     end
       
     factory :good_us_phone_number_settings do
-      phone_number '+1 (444) 444-4444'
+      phone_number "(444) 444-4444"
     
       factory :confirmed_settings do
         vault_id { FactoryGirl.create(:confirmed_gringotts_vault).id }

--- a/spec/models/gringotts/settings_spec.rb
+++ b/spec/models/gringotts/settings_spec.rb
@@ -30,7 +30,7 @@ module Gringotts
       @settings = FactoryGirl.create(:confirmed_settings)
       @settings.vault.confirmed_at.should_not be_nil
       
-      @settings.update_attributes!(phone_number: "+1 555-555-5555")
+      @settings.update_attributes!(phone_number: "555-555-5555")
       @settings.vault.confirmed_at.should be_nil
     end
     

--- a/spec/models/gringotts/settings_spec.rb
+++ b/spec/models/gringotts/settings_spec.rb
@@ -30,7 +30,7 @@ module Gringotts
       @settings = FactoryGirl.create(:confirmed_settings)
       @settings.vault.confirmed_at.should_not be_nil
       
-      @settings.update_attributes!(phone_number: "555-555-5555")
+      @settings.update_attributes!(phone_number: "+1 555-555-5555")
       @settings.vault.confirmed_at.should be_nil
     end
     

--- a/spec/models/gringotts/vault_spec.rb
+++ b/spec/models/gringotts/vault_spec.rb
@@ -38,9 +38,9 @@ module Gringotts
     end
     
     it "should always have a reference to the most-recent settings" do
-      new_phone_number = "+1 (800) 555-1212"
+      new_phone_number = "(800) 555-1212"
       @settings.update_attributes(phone_number: new_phone_number)
-      @gringotts.settings.phone_number.should == new_phone_number
+      @gringotts.settings.phone_number.should == '18005551212'
     end
     
     it "should be able to generate new codes" do

--- a/spec/models/gringotts/vault_spec.rb
+++ b/spec/models/gringotts/vault_spec.rb
@@ -38,7 +38,7 @@ module Gringotts
     end
     
     it "should always have a reference to the most-recent settings" do
-      new_phone_number = "(800) 555-1212"
+      new_phone_number = "+1 (800) 555-1212"
       @settings.update_attributes(phone_number: new_phone_number)
       @gringotts.settings.phone_number.should == new_phone_number
     end


### PR DESCRIPTION
The phone numbers in the specs were no longer valid, needed to update them to the latest format that phony was expecting.
