### PR TITLE
Persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-Gringotts 2FA (2-Factor Authentication) Engine for Rails
+Gringotts: 2FA Phone Verification Engine for Rails
 ------
 
-**Note:** This project is still very much pre-release (version < 1.0). Definitely *not* ready for production use. However, please *do* test it out on an experimental branch of your application and create github issues (with supporting documentation) related to what you find.
-
-**Additional Note:** This is currently being developed against Rails 4 which requires Ruby 1.9.3+. Support for Rails 3.2.x is definitely planned but will not become a priority until after an initial beta version for Rails 4 is ready.
+**Note:** This project is still pre-release (version < 1.0). Definitely *not* ready for production use and *will* change significantly in the near future. However, please *do* test it out on an experimental branch of your application and give your feedback!
 
 <img src="http://images2.wikia.nocookie.net/__cb20120724185750/harrypotter/images/2/25/Gringotts_New_Logo.jpg" width="50"> [![Build Status](https://travis-ci.org/conroywhitney/gringotts.png?branch=master)](https://travis-ci.org/conroywhitney/gringotts)  [![Code Climate](https://codeclimate.com/github/conroywhitney/gringotts.png)](https://codeclimate.com/github/conroywhitney/gringotts)
 
@@ -11,11 +9,38 @@ Gringotts 2FA (2-Factor Authentication) Engine for Rails
 What is Gringotts?
 --------
 
-Gringotts is a [two-factor authentication (2FA)](http://en.wikipedia.org/wiki/Multi-factor_authentication) [Rails Engine](http://guides.rubyonrails.org/engines.html). It sends a [one-time password](http://en.wikipedia.org/wiki/One-time_password) to users over SMS which verifies that they are who they say they are. All you need is a [Twilio](https://www.twilio.com/) account to send the SMS, and you are set.
+Gringotts is a plug-n-play [two-factor authentication (2FA)](http://en.wikipedia.org/wiki/Multi-factor_authentication) phone verification [rails engine](http://guides.rubyonrails.org/engines.html). It sends a [one-time password](http://en.wikipedia.org/wiki/One-time_password) to a user over SMS which is used to verify that the user is are who they say they are.
 
-Gringotts allows your users to optionally add 2FA to their existing accounts. Their mobile phone number is collected, validated, and stored encrypted in your database. When a user logs in from an unknown device (like an internet cafe), or if their last 2FA confirmation was more than 30 days ago, they are sent a 4-digit number through a text message that is valid for only a short period of time, and only from the device for which it was sent. After the user enters the correct number, they can use your site like normal. If they enter a wrong number too many times, they are locked out for a short time period. If they do not have access to, or have lost their mobile phone, there is a way for them to prove their identity through another means. (That last sentence is intentionally vague.)
 
-As a Rails Engine, Gringotts creates a set of models, views, and controllers to handle all of the user messaging, information collection, phone number confirmation, and verification. It is essentially an app within your app, bundling up and providing all the relevant functionality for handling two-factor authentication. If you want to change any of the interface or behaviour, you can optionally bring Gringott's content down into your application and overwrite it. 
+**For you**, it works like this:
+
+ 1. Sign up for a [Twilio](https://www.twilio.com/) account and add some credits
+
+ 2. Install and configure the Gringotts gem with your Twilio credentials
+
+ 3. Sit back and feel proud knowing that you made your users' accounts more secure
+
+
+**For your users**, it works like this:
+
+ 1. They choose to opt-in to phone verification to make their account more secure
+
+ 2. They enter their phone number and confirm the code sent via text message to their phone
+
+ 3. Every time they log in and are asked to enter a new code, they are reminded that their account is protected, and that only they are able to access their personal information
+
+
+Give It a Test Drive
+------------
+
+Sound too good to be true? Don't take my word for it, check it out for yourself:
+
+[http://gringotts-example.herokuapp.com](http://gringotts-example.herokuapp.com)
+
+
+See the entire changeset that took that demo app from being a regular rails app to having 2FA:
+
+[https://github.com/conroywhitney/gringotts-client/](https://github.com/conroywhitney/gringotts-client/)
 
 
 Installation
@@ -25,19 +50,47 @@ Add the Gringotts gem to your bundler Gemfile
 
     gem "gringotts"
     
-Mount the Gringotts engine in your `config/routes.rb` file for whatever virtual path you want to use (e.g., `/authentication`, `/security`, `/mobile-auth`, whatever you want). Note: please do not change the `:as => :gringotts_engine`
+Mount the Gringotts engine in your `config/routes.rb` file for whatever virtual path you want to use (e.g., `/authentication`, `/phone`, up to you). *Note: please do not change the `:as => :gringotts_engine`*
 
     mount Gringotts::Engine => "/authentication", :as => :gringotts_engine
 
-Add Gringotts' tables to your database (note: this only creates *new* tables; it does *not* modify any of your existing tables)
+Add Gringotts' tables to your database (note: this only creates *new* tables; it does *not* modify any of your existing tables. y4y!)
 
     bundle exec rake db:migrate
     
 Configure Gringotts with your `gringotts.yml` file, adding your Twilio account credentials, and optionally altering other default behaviour
 
-    twilio:
-      account_sid: *********************
-      auth_token:  *********************
+    twilio_settings: &twilio_settings
+      from_number: "1-###-###-####"
+      account_sid: "**********************************"
+      auth_token:  "********************************"
+
+    delivery_settings: &delivery_settings
+      enabled: true
+      phone_number_override: "1-###-###-####"
+  
+    defaults: &defaults
+      enabled: true
+      delivery:
+        <<: *delivery_settings
+      twilio:
+        <<: *twilio_settings
+      ignore_paths:
+        - /users/sign_out
+        - /users/sign_in
+
+    development:
+      <<: *defaults
+      delivery:
+        <<: *delivery_settings
+        enabled: false
+
+    test:
+      <<: *defaults
+    
+    production:
+      <<: *defaults
+      enabled: false
 
 Add Gringotts stylesheets to `app/assets/javascripts/application.js` (recommened before your `*= require_tree .` so you can override certain styles if you want)
 
@@ -47,60 +100,72 @@ Add Gringotts stylesheets to `app/assets/javascripts/application.js` (recommened
 
 And you should be all set. Fire up your application, log in, and you should see a prompt to turn on mobile phone authentication.
 
-Why Do I Need Two-Factor Authentication?
+
+Is Gringotts Secure?
+-------------
+
+As a gem whose main purpose is to provide additional security to your rails application, it is obviously important to address in what areas this gem is secure and how it can be improved. This will be an ongoing area of focus. By all means, don't take my word for this. Check out the code yourself. Join the conversation if you see an area for improvement.
+
+##Current Security Measures
+
+ * **Codes Expire:** If a user does not enter their code within a certain amount of time, that code becomes useless. This ensures that unused codes are not just sitting around waiting to be exploited.
+
+ * **One-Time Use Codes:** A code cannot be entered more than once. This prevents [replay attacks](http://en.wikipedia.org/wiki/Replay_attack).
+
+ * **Lock Out:** A user can only attempt to enter a maximum number of codes within a given period of time. This protects against [brute-force attacks]( http://en.wikipedia.org/wiki/Brute-force_attack)
+ 
+ * **Forward Secrecy:** Unlike other OTP systems (like Google Authenticator), even if one code is compromised, that does not affect future verifications.
+
+##Roadmap of Improvements
+
+ * **One-Way Encrypted Codes:** Store the codes like you store a password. After the initial sending of the code, there is no need to know the code’s value – only whether a user entry matches.
+
+ * **Two-Way Encrypted Phone Numbers:** Phone numbers need to be retrieved and used for sending new codes in the future; however, users’ phone numbers do *not* need to be stored in plain-text. 
+
+
+Why Bother with 2-Factor Authentication?
 -------
 
-### Public WiFi and Keyloggers
+Having 2-factor authentication adds one more layer of security to your users’ accounts. As they say, it’s “something you know, and something you have”. The combination of those two ensures that when your users log in, you know that it’s them, not somebody else who has their password. But, again, don’t take my word for it. Check out what these other talking heads have to say:
 
-When your users use your application over a public WiFi connection (like a Starbucks), or when they use an internet cafe, they are potentially exposing their account to malicious actors who can potentially discover their passwords and therefore access their account. By adding 2-Factor Authentication to your application, even if a user's password is compromised, the malicious actor will be unable to log in without access to the user's mobile phone. Problem solved.
-
-
-### Database Leaks
-
-It happens to the best: Dropbox, Twitter, Adobe, Sony; the list goes on and on. These days, it is best to assume that it is only a matter of time before your database is compromised. Once a malicious actor has access to your users' passwords and salts, it is only a matter of time before they are able to brute-force crack the passwords and thus gain access to your users' accounts. By adding 2-Factor Authentication that uses a random one-time-password (OTP), these cracked passwords are no longer enough to gain access -- they would either have to have access to your users' mobile phones, or your live database data, in order to gain entry.
-
-
-### NSA Overreach
-
-I don't know about you, but in my humble opinion, the Feds can go fuck themselves. In these days of [PRISM](http://en.wikipedia.org/wiki/PRISM_(surveillance_program) and [the NSA forcing companies to hand over encrypted passwords](http://www.npr.org/blogs/thetwo-way/2013/07/26/205709369/report-feds-have-asked-web-firms-for-users-passwords), adding one more layer of "fuck you" between the feds and your users' accounts is a worthy endeavour. Once they have demanded your SSL keys, encrypted passwords with salts, and in general undone all other security measures that you have put in place to protect the privacy of your users, they will still need one last thing to gain access to your users' accounts: the random one-time-password (OTP) sent to their mobile phones. This means either access to your live database, or intercepting the SMS message sent to your users' mobile phones. While both are possible under the powers the NSA has given itself, and thus this form of 2-Factor Authentication will not provide complete security against an unconstitutional overreach of the federal government, it is at least one more hoop they have to jump through to get their way. ┌∩┐(-_-)┌∩┐
-
-
-FAQ
------
-### Why Open-Source? Isn't that insecure?
-Gringotts was originally conceived as an Authentication-as-a-Service (AaaS) product, much like many of the existing ones out there (like [Swift Identity](https://www.swiftidentity.com/), [Duo Security](https://www.duosecurity.com/), and [Authy](https://www.authy.com/), among others). However, these closed-source "trust-us" models go against the best practices in cryptography and security where the more eyes looking at something, and the more people who try to break it, the more secure it gets. In closed-source, proprietary systems, a vulnurability could be discovered by a malicious actor and exploited (like [the attack against Dropbox](http://www.slashgear.com/dropbox-hack-allows-bypass-of-two-factor-authentication-05289228/)) without any white-hat actor having a chance to point out the issue before-hand.
-
-
-### OK, but then why not an Open-Source AaaS product?
-One word: decentralization. In these days of [PRISM](http://en.wikipedia.org/wiki/PRISM_(surveillance_program), [the NSA forcing companies to hand over encrypted passwords](http://www.npr.org/blogs/thetwo-way/2013/07/26/205709369/report-feds-have-asked-web-firms-for-users-passwords), and general movement towards single-sign-on (SSO) (which I think of more like [single point of failure](http://en.wikipedia.org/wiki/Single_sign-on#Security)) with monolothic companies like Facebook and Google, we are making it easier for malicious actors to gain access to our information by centralizing and consolidating. I think we need to start moving in the opposite direction by creating strong, decentralized systems to store our information. The more spread out and decentralized a user's credentials are, the harder it is for hackers and other malicious agents (read: the government) to abuse a user's information. It's time to take back our privacy. Gringotts is a small step in that direction.
-
-
-### Why SMS? Why not Google Authenticator? Or a proprietary application?
-
- 1. **Ease and adoption.** Simply put, SMS is easier and more ubiquitious than Google Authenticator. (Nearly) everyone has SMS capability, but not everyone has a smart-phone which can run an app like Google Authenticator; and even fewer have the patience (or tech savvy) to correctly set up their phones. The same goes for a proprietary app. Entering a phone number and confirming an SMS message is a *lot* easier for users, and therefore they are more likely to adopt and benefit from the privacy and security that we are trying to provide.
-
- 1. **Security.** The randomly-generated one-time-password (OTP) sent through SMS is more secure than the private-key time-based one-time-password (TOTP) that Google Authenticator uses. Why? Well, if your database is compromised, your users' passwords and salts are sitting right next to the private TOTP key that was supposed to keep hackers out of your users' accounts. Ooops! With a random password, a database leak does not matter. The code the malicious agent will see is useless. They would need access to your users' mobile phones.
+> No matter how complex, no matter how unique, your passwords can no longer protect you... [H]ackers [are regularly] breaking into computer systems and releasing lists of usernames and passwords on the open web.
+<br>
  
+ \- Matt Honan, Wired.com, *[Kill the Password: Why a String of Characters Can't Protect Us Anymore](http://www.wired.com/gadgetlab/2012/11/ff-mat-honan-password-hacker/all/)*
 
-### Is Gringotts secure?
+<br>
+> 2-step verification drastically reduces the chances of having the personal information in your Google account stolen by someone else. Why? Because hackers would have to not only get your password and your username, they'd have to get a hold of your phone.
+<br>
 
-I'm doing the best that I can to make the answer to that question a *"yes"*, but I need your help seeing issues and flaws I have missed over overlooked. That said, here are a few known aspects of security, and how Gringotts handles them:
+ \- *[Google 2-Step Verification Home](https://support.google.com/a/answer/175197)*
 
-**Random OTP > TOTP:** Most 2-Factor Auth services use time-based one-time-passwords (TOTP) that utilize a shared secret between client and server in order to generate a password that changes every 60 seconds. While this is cool, and most people have jumped on this bandwagon, I personally think that it's not suitable for our purposes. With Gringotts, the idea is that 2FA becomes a part of your system, decentralized, without any 3rd-party. If you store the private TOTP shared secret in your database, next to your user's password and salt, you are opening yourself up to a security breach. By using a Random OTP with a short expiration time, even if a malicious agent sees the last-sent OTP, it will no longer be usable.
+<br>
+> If [two-step verification], were used on all limited-access Web sites, the passwords wouldn't have to be long and complex. But many Web users have easy-to-guess passwords in just one-step verification, which is highly imprudent.
+<br>
+ 
+ \- Randall Stross, New York Times, *[Doing the Two-Step, Beyond the A.T.M.](http://www.nytimes.com/2012/10/14/technology/two-step-verification-is-inconvenient-but-more-secure.html)*
 
-**Man in the Middle Attacks:** TODO
+<br>
+> With [single-factor authentication] becoming increasingly unreliable as a security measure, two-factor authentication is rapidly gaining importance for logging into online accounts.
+<br>
+ 
+ \- Tina Sieber, MakeUseOf.com, *[What Is Two-Factor Authentication, And Why You Should Use It](http://www.makeuseof.com/tag/what-is-two-factor-authentication-and-why-you-should-use-it/)*
 
-**Replay Attacks:** TODO
 
-**Cross-Site Request Forgery:** TODO
+The Gringotts Philosophy
+-------
+ * Gringotts is about increased **security consciousness**. It is the beginning of a conversation between users and makers about how we can work together to make the internet a safer and more private place for everyone.
+
+ * Gringotts is about **empowering users** to take back control over their online identities. It is about giving developers the tools necessary to assist their users.
+
+ * Gringotts is about **decentralization** in an age of aggregation. Single points of failure – even when distributed -- have proven to be a failed experiment. 
+
+ * Gringotts is about **collaboration**. Moving forward, every action should be considered in the context of whether this promotes openness, or closed systems.
 
 
 Contributing
 ------
-
-I am actively and eagerly seeking input and contributions from the open-source community regarding:
-
- * **High Level:** Constructive criticism of this implementation of 2-Factor Authentication (random OTP send through SMS)
+ * **High Level:** Constructive criticism of this implementation of 2-Factor Authentication (OTP send through SMS)
 
  * **Flow:** Suggestions on improving the user-experience (opt-in, confirmation, verification, locked-out, opt-out)
  
@@ -118,11 +183,13 @@ Special Thanks To
 
 * Abhishek for philosophical discussions about motivation and the lack there-of. "Don't think. Just do it."
 
-* [jlukic](https://github.com/jlukic/) for inspiring me to with his kick.ass. [Semantic-UI](http://semantic-ui.com) project. You're my hero.
+* [jlukic](https://github.com/jlukic/) for inspiring me to with his kick.ass. [Semantic-UI](http://semantic-ui.com) project. Keep up the great work, dude.
 
 * [Nitrous.io](https://www.nitrous.io/join/012YtP048go) for the awesome web-based IDE that allows me to work from internet cafes. (disclaimer: referral link)
 
 * [Supertramp Hostel](http://www.supertramphostel.com/en) and Machu Picchu, Peru for 8 months of good times, food, accomodation, internet, and motivation to get the hell out of here and get on with my life. Thanks, I really needed this. =)
+
+* All the other blogs, tutorials, websites, and gems that have influenced and acted as a model for this gem. Open Source Software FTW!
 
 
 Disclaimer

--- a/README.md
+++ b/README.md
@@ -46,19 +46,28 @@ See the entire changeset that took that demo app from being a regular rails app 
 Installation
 -------
 
-Add the Gringotts gem to your bundler Gemfile
+**1. Add the Gringotts gem** to your bundler Gemfile
 
     gem "gringotts"
     
-Mount the Gringotts engine in your `config/routes.rb` file for whatever virtual path you want to use (e.g., `/authentication`, `/phone`, up to you). *Note: please do not change the `:as => :gringotts_engine`*
+
+**2. Mount the Gringotts engine** in your `config/routes.rb` file for whatever virtual path you want to use (e.g., `/authentication`, `/phone`, `/omg-so-secure`, whatever you want).
+
+*Note: please do not change the `:as => :gringotts_engine`. That part is important.*
 
     mount Gringotts::Engine => "/authentication", :as => :gringotts_engine
 
-Add Gringotts' tables to your database (note: this only creates *new* tables; it does *not* modify any of your existing tables. y4y!)
+
+**3. Add Gringotts' tables** to your database
+
+*Note: this only creates new tables; it does not modify any of your existing tables. y4y!*
 
     bundle exec rake db:migrate
     
-Configure Gringotts with your `gringotts.yml` file, adding your Twilio account credentials, and optionally altering other default behaviour
+
+**4. Configure Gringotts** with your `gringotts.yml` file, adding your Twilio account credentials, and optionally altering other default behaviour
+
+*Note: `from_number` is what Twilio gives you; `phone_number_override` is for testing in development.*
 
     twilio_settings: &twilio_settings
       from_number: "1-###-###-####"
@@ -92,19 +101,23 @@ Configure Gringotts with your `gringotts.yml` file, adding your Twilio account c
       <<: *defaults
       enabled: false
 
-Add Gringotts stylesheets to `app/assets/javascripts/application.js` (recommened before your `*= require_tree .` so you can override certain styles if you want)
+
+**5. Add Gringotts stylesheets** to `app/assets/javascripts/application.js`
+
+*Note: recommened before your `*= require_tree .` so you can override certain styles if you want*
 
     *= require_self
     *= require gringotts
     *= require_tree .
 
-And you should be all set. Fire up your application, log in, and you should see a prompt to turn on mobile phone authentication.
+
+**6. Fire up your application**, log in, and you should see a prompt to turn on mobile phone authentication.
 
 
 Is Gringotts Secure?
 -------------
 
-As a gem whose main purpose is to provide additional security to your rails application, it is obviously important to address in what areas this gem is secure and how it can be improved. This will be an ongoing area of focus. By all means, don't take my word for this. Check out the code yourself. Join the conversation if you see an area for improvement.
+As a gem whose main purpose is to provide additional security to your rails application, it is obviously important to address in what areas this gem is secure and how it can be improved. This will be an ongoing area of focus. By all means, don't take my word for this. Check out the code yourself. Join the conversation if you see an area for improvement. Suggest a "what if?" test case. Point out how something could be abused. Be paranoid! There are no dumb scenarios.
 
 ##Current Security Measures
 
@@ -114,7 +127,7 @@ As a gem whose main purpose is to provide additional security to your rails appl
 
  * **Lock Out:** A user can only attempt to enter a maximum number of codes within a given period of time. This protects against [brute-force attacks]( http://en.wikipedia.org/wiki/Brute-force_attack)
  
- * **Forward Secrecy:** Unlike other OTP systems (like Google Authenticator), even if one code is compromised, that does not affect future verifications.
+ * **Forward Secrecy:** Unlike other OTP systems (like Google Authenticator) that rely on a shared secret, even if one Gringotts code is compromised, future verifications will still be secure.
 
 ##Roadmap of Improvements
 
@@ -127,25 +140,26 @@ Why Bother with 2-Factor Authentication?
 -------
 
 Having 2-factor authentication adds one more layer of security to your users’ accounts. As they say, it’s “something you know, and something you have”. The combination of those two ensures that when your users log in, you know that it’s them, not somebody else who has their password. But, again, don’t take my word for it. Check out what these other talking heads have to say:
+<br>
 
 > No matter how complex, no matter how unique, your passwords can no longer protect you... [H]ackers [are regularly] breaking into computer systems and releasing lists of usernames and passwords on the open web.
 <br>
  
  \- Matt Honan, Wired.com, *[Kill the Password: Why a String of Characters Can't Protect Us Anymore](http://www.wired.com/gadgetlab/2012/11/ff-mat-honan-password-hacker/all/)*
 
-<br>
+
 > 2-step verification drastically reduces the chances of having the personal information in your Google account stolen by someone else. Why? Because hackers would have to not only get your password and your username, they'd have to get a hold of your phone.
 <br>
 
  \- *[Google 2-Step Verification Home](https://support.google.com/a/answer/175197)*
 
-<br>
+
 > If [two-step verification], were used on all limited-access Web sites, the passwords wouldn't have to be long and complex. But many Web users have easy-to-guess passwords in just one-step verification, which is highly imprudent.
 <br>
  
  \- Randall Stross, New York Times, *[Doing the Two-Step, Beyond the A.T.M.](http://www.nytimes.com/2012/10/14/technology/two-step-verification-is-inconvenient-but-more-secure.html)*
 
-<br>
+
 > With [single-factor authentication] becoming increasingly unreliable as a security measure, two-factor authentication is rapidly gaining importance for logging into online accounts.
 <br>
  
@@ -192,6 +206,19 @@ Special Thanks To
 * All the other blogs, tutorials, websites, and gems that have influenced and acted as a model for this gem. Open Source Software FTW!
 
 
+License
+-------
+Copyright 2013 Conroy Whitney
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 Disclaimer
 -----
 Gringotts 2-Factor Authentication is not associated with Warner Bros. Entertainment Inc., J.K. Rowling, or any of the "Harry Potter" books or films. HARRY POTTER is a registered trade-mark of Warner Bros. Entertainment Inc.
+
+*Note: I never thought I would ever have a reason to need to use a disclaimer like this... fun!*

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Give It a Test Drive
 
 Sound too good to be true? Don't take my word for it, check it out for yourself:
 
-[http://gringotts-example.herokuapp.com](http://gringotts-example.herokuapp.com)
+[http://gringotts.herokuapp.com](http://gringotts.herokuapp.com)
 
 
 See the entire changeset that took that demo app from being a regular rails app to having 2FA:
 
-[https://github.com/conroywhitney/gringotts-client/](https://github.com/conroywhitney/gringotts-client/)
+[https://github.com/conroywhitney/gringotts-client/compare/master...installed](https://github.com/conroywhitney/gringotts-client/compare/master...installed)
 
 
 Installation

--- a/app/assets/stylesheets/gringotts/verify.css
+++ b/app/assets/stylesheets/gringotts/verify.css
@@ -19,3 +19,8 @@
   margin: 18px 15px 15px 0px;
   padding: 14px 22px;
 }
+
+#gringotts.confirm input[type="checkbox"],
+#gringotts.verify input[type="checkbox"], label {
+  font-size: 14px;
+}

--- a/app/controllers/gringotts/verification_controller.rb
+++ b/app/controllers/gringotts/verification_controller.rb
@@ -39,8 +39,8 @@ module Gringotts
       if @attempt.successful?
         # remember that they have been verified
         @gringotts.verify!(session)
-        gringotts_recognize!
-        
+        gringotts_recognize! if params[:remember_me].present?
+
         # if account was locked before, unlock!
         @gringotts.unlock! if @gringotts.locked?
         

--- a/app/helpers/gringotts/gringotts_helper.rb
+++ b/app/helpers/gringotts/gringotts_helper.rb
@@ -33,7 +33,7 @@ module Gringotts
       if cookie_hash.nil? || gringotts_owner.nil?
         false
       else
-        (cookie_hash[:user_id] == gringotts_owner.id) && (cookie_hash[:valid_until] > Time.now)
+        (cookie_hash[:user_id] == gringotts_owner.id) && (Time.parse(cookie_hash[:valid_until]) > Time.now)
       end
     end
     

--- a/app/helpers/gringotts/gringotts_helper.rb
+++ b/app/helpers/gringotts/gringotts_helper.rb
@@ -30,7 +30,6 @@ module Gringotts
     
     def gringotts_recognized?
       cookie_hash = JSON.parse(cookies.signed[COOKIE_KEY], {:symbolize_names => true}) unless cookies[COOKIE_KEY].nil?
-      puts "Checking cookie hash: #{cookie_hash}"
       if cookie_hash.nil? || gringotts_owner.nil?
         false
       else

--- a/app/models/gringotts/settings.rb
+++ b/app/models/gringotts/settings.rb
@@ -5,6 +5,7 @@ module Gringotts
     
     belongs_to :vault
     validates  :vault_id,     presence: true, uniqueness: true
+    phony_normalize :phone_number, :default_country_code => 'US'
     validates  :phone_number, presence: true, uniqueness: true, phony_plausible: true
     
     after_update :unconfirm!, :if => :phone_number_changed?

--- a/app/views/gringotts/verification/_code_form.html.erb
+++ b/app/views/gringotts/verification/_code_form.html.erb
@@ -7,8 +7,8 @@
     <%= f.text_field :code_received %>
   
     <%= f.submit "Verify Code" %>
-  
-  <% end %>
+    <%= check_box_tag :remember_me %> <%= label_tag :remember_me,'Remember me on this device' %>
+   <% end %>
   
   <%- if flash[:gringotts_error] %>
     <div class="error">

--- a/app/views/gringotts/verification/confirm.html.erb
+++ b/app/views/gringotts/verification/confirm.html.erb
@@ -21,7 +21,7 @@
       </div><!-- /step -->
 
       <div class="phone-number">
-        <%= @gringotts.phone_number %>
+        <%= @gringotts.phone_number.phony_formatted(:format => :international, :spaces => '-') %>
       </div>
       
       <%= render :partial => "code_form" %>

--- a/db/migrate/20131025012829_add_successful_to_gringotts_attempts.rb
+++ b/db/migrate/20131025012829_add_successful_to_gringotts_attempts.rb
@@ -1,5 +1,5 @@
 class AddSuccessfulToGringottsAttempts < ActiveRecord::Migration
   def change
-    add_column :gringotts_attempts, :successful, :boolean, null: false, default: 0
+    add_column :gringotts_attempts, :successful, :boolean, null: false, default: false
   end
 end

--- a/features/persistence/recognized.feature
+++ b/features/persistence/recognized.feature
@@ -32,18 +32,61 @@ Feature: Recognizing devices
     When I sign out
     Then I am not recognized
 
-  Scenario: Confirmed user recognized after confirming
+  Scenario: Confirmed user not recognized after confirming without checking remember me
     Given I am confirmed
     When I return to the site
-    Then I am recognized
+    Then I am not recognized
   
-  Scenario: Confirmed user recognized even after signing out
+  Scenario: Confirmed user not recognized even after signing out without checking remember me
     Given I am confirmed
     When I sign out
-    Then I am recognized
+    Then I am not recognized
     
-  Scenario: Confirmed user recognized even after logging back in
+  Scenario: Confirmed user not recognized even after logging back in without checking remember me
     Given I am confirmed
     When I sign out
       And I sign in with valid credentials
+    Then I am not recognized
+
+  Scenario: Confirmed user recognized after confirming and checking remember me
+    Given I am confirmed with remember me
+    When I return to the site
     Then I am recognized
+
+  Scenario: Confirmed user recognized even after signing out and checking remember me
+    Given I am confirmed with remember me
+    When I sign out
+    Then I am recognized
+
+  Scenario: Confirmed user recognized even after logging back in and checking remember me
+    Given I am confirmed with remember me
+    When I sign out
+      And I sign in with valid credentials
+    Then I am recognized
+
+
+  Scenario: User not recognized after logging back in after successful verification but not checking remember me
+    Given I am logged in
+      And I am opted-in
+      And I am on the verification page
+    When I enter the correct code
+      And I receive a correct code message
+      And I sign out
+      And I am logged in
+    Then I am not recognized
+      And I am on the prompt page
+
+
+  Scenario: User recognized after logging back in after successful verification and checking remember me
+    Given I am logged in
+      And I am opted-in
+      And I am on the verification page
+    When I enter the correct code and check remember me
+      And I receive a correct code message
+      And I sign out
+      And I am logged in
+    Then I am recognized
+      And I see a successful sign in message
+
+@wip
+Scenario: User verifies with "remember me" but a different user logging in needing 2FA will still be prompted

--- a/features/step_definitions/devise_steps.rb
+++ b/features/step_definitions/devise_steps.rb
@@ -41,7 +41,7 @@ def sign_in
   visit '/users/sign_in'
   fill_in "user_email", :with => @visitor[:email]
   fill_in "user_password", :with => @visitor[:password]
-  click_button "Log in"
+  find('input[type="submit"]').click
 end
 
 def sign_out

--- a/features/step_definitions/devise_steps.rb
+++ b/features/step_definitions/devise_steps.rb
@@ -41,7 +41,7 @@ def sign_in
   visit '/users/sign_in'
   fill_in "user_email", :with => @visitor[:email]
   fill_in "user_password", :with => @visitor[:password]
-  click_button "Sign in"
+  click_button "Log in"
 end
 
 def sign_out

--- a/features/step_definitions/persistence_steps.rb
+++ b/features/step_definitions/persistence_steps.rb
@@ -1,12 +1,10 @@
 Then(/^I am not recognized$/) do
-  show_me_the_cookies
   cookie = get_me_the_cookie('gringotts_recognized')
   cookie.present?.should be_false
 #  gringotts_recognized?.should be_false
 end
 
 Then(/^I am recognized$/) do
-  show_me_the_cookies
   cookie = get_me_the_cookie('gringotts_recognized')
   cookie.present?.should be_true
 #  gringotts_recognized?.should be_true

--- a/features/step_definitions/persistence_steps.rb
+++ b/features/step_definitions/persistence_steps.rb
@@ -1,9 +1,13 @@
 Then(/^I am not recognized$/) do
   show_me_the_cookies
-  gringotts_recognized?.should be_false
+  cookie = get_me_the_cookie('gringotts_recognized')
+  cookie.present?.should be_false
+#  gringotts_recognized?.should be_false
 end
 
 Then(/^I am recognized$/) do
   show_me_the_cookies
-  gringotts_recognized?.should be_true
+  cookie = get_me_the_cookie('gringotts_recognized')
+  cookie.present?.should be_true
+#  gringotts_recognized?.should be_true
 end

--- a/features/step_definitions/verification_steps.rb
+++ b/features/step_definitions/verification_steps.rb
@@ -29,6 +29,15 @@ Given(/^I am confirmed$/) do
   gringotts.confirmed?.should be_true
 end
 
+Given(/^I am confirmed with remember me$/) do
+  create_user
+  sign_in
+  opt_in
+  check 'remember_me'
+  submit_code gringotts.recent_code.value
+  gringotts.confirmed?.should be_true
+end
+
 When(/^I need to confirm my phone number$/) do
   create_user
   sign_in
@@ -56,6 +65,10 @@ Given(/^I go to the verification page$/) do
   visit verification_path
 end
 
+Given(/^I am on the prompt page$/) do
+  page.current_path.should == prompt_path
+end
+
 When(/^I enter a blank code$/) do
   submit_code ""
 end
@@ -65,6 +78,11 @@ When(/^I enter the code "(.*?)"$/) do |code|
 end
 
 When(/^I enter the correct code$/) do
+  submit_code gringotts.recent_code.value
+end
+
+When(/^I enter the correct code and check remember me$/) do
+  check 'remember_me'
   submit_code gringotts.recent_code.value
 end
 

--- a/gemfiles/rails_3.1.gemfile
+++ b/gemfiles/rails_3.1.gemfile
@@ -6,6 +6,7 @@ gem "factory_girl_rails", :group=>[:development, :test]
 gem "codeclimate-test-reporter", :group=>[:test], :require=>nil
 gem "figaro", :group=>[:development, :test]
 gem "appraisal", "0.5.2", :group=>[:development, :test]
+gem "show_me_the_cookies", :group=>[:development, :test]
 gem "rails", "~> 3.1.12"
 gem "devise", "~> 2.2.8"
 gem "gringotts", :path=>"../"

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -6,6 +6,7 @@ gem "factory_girl_rails", :group=>[:development, :test]
 gem "codeclimate-test-reporter", :group=>[:test], :require=>nil
 gem "figaro", :group=>[:development, :test]
 gem "appraisal", "0.5.2", :group=>[:development, :test]
+gem "show_me_the_cookies", :group=>[:development, :test]
 gem "rails", "~> 3.2.15"
 gem "devise", "~> 3.1.2"
 gem "gringotts", :path=>"../"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -7,6 +7,7 @@ gem "factory_girl_rails", :group=>[:development, :test]
 gem "codeclimate-test-reporter", :group=>[:test], :require=>nil
 gem "figaro", :group=>[:development, :test]
 gem "appraisal", "0.5.2", :group=>[:development, :test]
+gem "show_me_the_cookies", :group=>[:development, :test]
 gem "rails", "~> 4.0.0"
 gem "gringotts", :path=>"../"
 

--- a/lib/gringotts/version.rb
+++ b/lib/gringotts/version.rb
@@ -1,3 +1,3 @@
 module Gringotts
-  VERSION = "0.6.1"
+  VERSION = "0.6.1.1"
 end

--- a/lib/gringotts/version.rb
+++ b/lib/gringotts/version.rb
@@ -1,3 +1,3 @@
 module Gringotts
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/spec/factories/gringotts_settings.rb
+++ b/spec/factories/gringotts_settings.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     end
       
     factory :good_us_phone_number_settings do
-      phone_number "(444) 444-4444"
+      phone_number '+1 (444) 444-4444'
     
       factory :confirmed_settings do
         vault_id { FactoryGirl.create(:confirmed_gringotts_vault).id }
@@ -22,7 +22,7 @@ FactoryGirl.define do
     end
       
     factory :good_pe_phone_number_settings do
-      phone_number "(084) 791224"
+      phone_number "+41 44 111 22 33"
     end
     
   end

--- a/spec/factories/gringotts_settings.rb
+++ b/spec/factories/gringotts_settings.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     end
       
     factory :good_us_phone_number_settings do
-      phone_number '+1 (444) 444-4444'
+      phone_number "(444) 444-4444"
     
       factory :confirmed_settings do
         vault_id { FactoryGirl.create(:confirmed_gringotts_vault).id }

--- a/spec/models/gringotts/settings_spec.rb
+++ b/spec/models/gringotts/settings_spec.rb
@@ -30,7 +30,7 @@ module Gringotts
       @settings = FactoryGirl.create(:confirmed_settings)
       @settings.vault.confirmed_at.should_not be_nil
       
-      @settings.update_attributes!(phone_number: "+1 555-555-5555")
+      @settings.update_attributes!(phone_number: "555-555-5555")
       @settings.vault.confirmed_at.should be_nil
     end
     

--- a/spec/models/gringotts/settings_spec.rb
+++ b/spec/models/gringotts/settings_spec.rb
@@ -30,7 +30,7 @@ module Gringotts
       @settings = FactoryGirl.create(:confirmed_settings)
       @settings.vault.confirmed_at.should_not be_nil
       
-      @settings.update_attributes!(phone_number: "555-555-5555")
+      @settings.update_attributes!(phone_number: "+1 555-555-5555")
       @settings.vault.confirmed_at.should be_nil
     end
     

--- a/spec/models/gringotts/vault_spec.rb
+++ b/spec/models/gringotts/vault_spec.rb
@@ -38,9 +38,9 @@ module Gringotts
     end
     
     it "should always have a reference to the most-recent settings" do
-      new_phone_number = "+1 (800) 555-1212"
+      new_phone_number = "(800) 555-1212"
       @settings.update_attributes(phone_number: new_phone_number)
-      @gringotts.settings.phone_number.should == new_phone_number
+      @gringotts.settings.phone_number.should == '18005551212'
     end
     
     it "should be able to generate new codes" do

--- a/spec/models/gringotts/vault_spec.rb
+++ b/spec/models/gringotts/vault_spec.rb
@@ -38,7 +38,7 @@ module Gringotts
     end
     
     it "should always have a reference to the most-recent settings" do
-      new_phone_number = "(800) 555-1212"
+      new_phone_number = "+1 (800) 555-1212"
       @settings.update_attributes(phone_number: new_phone_number)
       @gringotts.settings.phone_number.should == new_phone_number
     end


### PR DESCRIPTION
Extra work on the persistence branch:
- Made persistence cookie signed and with stuffed some info in it to tie to user
- Validate persistence cookie is for user logging in
- Only drop persistence cookie when users says "remember me on this device"
- Add check box for remember me, off by default (maybe it should default to on during signup?)
- Specs to validate remember me behavior (could use a couple more)
- Fix older spec to check for persistence cookie (not ideal solution, but issue related to cookies and capybara, see this for an example: http://stackoverflow.com/questions/19325960/rails-cucumber-capybara-how-to-set-retrieve-cookies-in-tests)
- Brought branch up-to-date with master (needed my fixed tests from other PR...sorry)
